### PR TITLE
task-57-hover-btn-product-box

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -18,14 +18,15 @@ const ProductBox = ({ favorite, comparision, name, price, promo, stars, img }) =
       <div className={styles.photo}>
         <img src={img} alt={name} />
         {promo && <div className={styles.sale}>{promo}</div>}
+        <div className={styles.buttons}>
+          <Button variant='small'>Quick View</Button>
+          <Button variant='small'>
+            <FontAwesomeIcon icon={faShoppingBasket}></FontAwesomeIcon> ADD TO CART
+          </Button>
+        </div>
       </div>
     </Link>
-    <div className={styles.buttons}>
-      <Button variant='small'>Quick View</Button>
-      <Button variant='small'>
-        <FontAwesomeIcon icon={faShoppingBasket}></FontAwesomeIcon> ADD TO CART
-      </Button>
-    </div>
+
     <div className={styles.content}>
       <Link to={`/product/${name}`}>
         <h5>{name}</h5>

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -46,13 +46,13 @@
   }
 
   &:hover{
-    @extend %hover-effects;
     .buttons {
       display: flex;
     }
     .actions{
       .price{
         :last-child{
+          @extend %hover-effects;
           background-color: $primary;
         }
       }

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -4,6 +4,7 @@
   background-color: $productbox-background;
   border: 1px solid $productbox-border;
   margin-bottom: 2rem;
+  position: relative;
 
   .photo {
     position: relative;
@@ -29,8 +30,11 @@
     }
 
     .buttons {
-      display: flex;
+      display: none;
       justify-content: space-between;
+      position: absolute;
+      width: 100%;
+      bottom: 0;
     }
     img{
       object-fit: cover;
@@ -40,15 +44,23 @@
       height: 260px;
     }
   }
-  .buttons {
-    display: flex;
-    justify-content: space-between;
+
+  &:hover{
+    .buttons {
+      display: flex;
+    }
+    .actions{
+      .price{
+        :last-child{
+          background-color: $primary;
+        }
+      }
+    }
   }
 
   .content {
     text-align: center;
     padding: 20px;
-
     h5 {
       color: $primary;
       font-size: 16px;

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -46,6 +46,7 @@
   }
 
   &:hover{
+    @extend %hover-effects;
     .buttons {
       display: flex;
     }


### PR DESCRIPTION
Buttony "Quick view" oraz "Add to cart" powinny być widoczne tylko na hover całego boksa z produktem. Wtedy też powinno zmieniać się tło ceny. 
Wizualizacja:
![image](https://github.com/odevpl/wdp2403/assets/151164474/2808afb5-3771-442e-89a9-400eaf7e3669)
