### PR TITLE
task-59-porownywanie-produktow

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -8,6 +8,10 @@ import Button from '../Button/Button';
 import Stars from '../Stars/Stars';
 import { Link } from 'react-router-dom/cjs/react-router-dom.min';
 import clsx from 'clsx';
+import { useDispatch } from 'react-redux';
+import { addToCompare } from '../../../redux/productsRedux';
+import { getCompareProducts } from '../../../redux/productsRedux';
+import { useSelector } from 'react-redux';
 
 const ProductBox = ({
   id,
@@ -20,49 +24,74 @@ const ProductBox = ({
   userStars,
   img,
   oldPrice,
-}) => (
-  <div className={styles.root}>
-    <div className={styles.photo}>
-      <Link to={`/product/${name}`}>
-        <img src={img} alt={name} />
-        {promo && <div className={styles.sale}>{promo}</div>}
-      </Link>
-      <div className={styles.buttons}>
-        <Button variant='small'>Quick View</Button>
-        <Button variant='small'>
-          <FontAwesomeIcon icon={faShoppingBasket}></FontAwesomeIcon> ADD TO CART
-        </Button>
-      </div>
-    </div>
+}) => {
+  const dispatch = useDispatch();
+  const compareProducts = useSelector(state => getCompareProducts(state));
 
-    <div className={styles.content}>
-      <Link to={`/product/${name}`}>
-        <h5>{name}</h5>
-      </Link>
-      <Stars stars={stars} userStars={userStars} id={id} />
-    </div>
-    <div className={styles.line}></div>
-    <div className={styles.actions}>
-      <div className={styles.outlines}>
-        <Button variant='outline' favorite={favorite}>
-          <FontAwesomeIcon icon={faHeart}>Favorite</FontAwesomeIcon>
-        </Button>
-        <Button variant='outline' comparision={comparision}>
-          <FontAwesomeIcon icon={faExchangeAlt}>Add to compare</FontAwesomeIcon>
-        </Button>
+  const isProductAlreadyCompared = compareProducts.some(product => product.id === id);
+
+  const handleAddToCompare = e => {
+    e.preventDefault();
+
+    if (!isProductAlreadyCompared) {
+      if (compareProducts.length < 4) {
+        dispatch(addToCompare(id));
+      } else {
+        alert('Maximum 4 products can be added to comparision.');
+      }
+    } else {
+      alert('This product is already included in comparision.');
+      return;
+    }
+  };
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.photo}>
+        <Link to={`/product/${name}`}>
+          <img src={img} alt={name} />
+          {promo && <div className={styles.sale}>{promo}</div>}
+        </Link>
+        <div className={styles.buttons}>
+          <Button variant='small'>Quick View</Button>
+          <Button variant='small'>
+            <FontAwesomeIcon icon={faShoppingBasket}></FontAwesomeIcon> ADD TO CART
+          </Button>
+        </div>
       </div>
-      <div className={styles.price}>
-        <span className={clsx(oldPrice === 0 && styles.active, styles.oldPrice)}>
-          {' '}
-          $ {oldPrice}
-        </span>
-        <Button noHover variant='small'>
-          $ {price}
-        </Button>
+      <div className={styles.content}>
+        <Link to={`/product/${name}`}>
+          <h5>{name}</h5>
+        </Link>
+        <Stars stars={stars} userStars={userStars} id={id} />
+      </div>
+      <div className={styles.line}></div>
+      <div className={styles.actions}>
+        <div className={styles.outlines}>
+          <Button variant='outline' favorite={favorite}>
+            <FontAwesomeIcon icon={faHeart}>Favorite</FontAwesomeIcon>
+          </Button>
+          <Button
+            variant='outline'
+            comparision={comparision}
+            onClick={handleAddToCompare}
+          >
+            <FontAwesomeIcon icon={faExchangeAlt}>Add to compare</FontAwesomeIcon>
+          </Button>
+        </div>
+        <div className={styles.price}>
+          <span className={clsx(oldPrice === 0 && styles.active, styles.oldPrice)}>
+            {' '}
+            $ {oldPrice}
+          </span>
+          <Button noHover variant='small'>
+            $ {price}
+          </Button>
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 ProductBox.propTypes = {
   children: PropTypes.node,

--- a/src/components/common/ProductBox/ProductBox.test.js
+++ b/src/components/common/ProductBox/ProductBox.test.js
@@ -1,10 +1,16 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ProductBox from './ProductBox';
+import { Provider } from 'react-redux';
+import store from '../../../redux/store';
 
 describe('Component ProductBox', () => {
   it('should render without crashing', () => {
-    const component = shallow(<ProductBox />);
+    const component = shallow(
+      <Provider store={store}>
+        <ProductBox />
+      </Provider>
+    );
     expect(component).toBeTruthy();
   });
 });

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -2,6 +2,7 @@ import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import styles from './NewFurniture.module.scss';
 import ProductBox from '../../common/ProductBox/ProductBox';
+import StickyBar from '../StickyBar/StickyBar';
 import { DeviceTypeContext } from '../../layout/MainLayout/MainLayout';
 import clsx from 'clsx';
 import FadeIn from 'react-fade-in/lib/FadeIn';
@@ -73,6 +74,7 @@ const NewFurniture = ({ categories, products }) => {
           ))}
         </div>
       </div>
+      <StickyBar />
     </div>
   );
 };

--- a/src/components/features/StickyBar/StickyBar.js
+++ b/src/components/features/StickyBar/StickyBar.js
@@ -1,0 +1,46 @@
+import styles from './StickyBar.module.scss';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
+import Button from '../../common/Button/Button';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { removeCompare } from '../../../redux/productsRedux';
+import { getCompareProducts } from '../../../redux/productsRedux';
+
+const StickyBar = () => {
+  const dispatch = useDispatch();
+  const compareProducts = useSelector(state => getCompareProducts(state));
+
+  const removehandler = (e, product) => {
+    e.preventDefault();
+    dispatch(removeCompare(product.id));
+  };
+
+  if (!compareProducts.length) {
+    return '';
+  } else
+    return (
+      <div className={styles.compareWrapper}>
+        {compareProducts.map(product => (
+          <div
+            className={styles.compareImage}
+            key={product.id}
+            style={{
+              backgroundImage: `url(${product.img})`,
+            }}
+          >
+            <Button
+              onClick={e => removehandler(e, product)}
+              className={styles.removeButton}
+            >
+              <FontAwesomeIcon icon={faTimes} />
+            </Button>
+          </div>
+        ))}
+        <Button>Compare</Button>
+      </div>
+    );
+};
+
+export default StickyBar;

--- a/src/components/features/StickyBar/StickyBar.module.scss
+++ b/src/components/features/StickyBar/StickyBar.module.scss
@@ -1,0 +1,38 @@
+@import "../../../styles/settings.scss";
+
+.compareWrapper {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  height: 25vh;
+  background-color: $stickybar-background;
+  z-index: 1;
+  border-top: 2px solid $stickybar-border;
+
+  .compareImage {
+    position: relative;
+    height: 90%;
+    width: 10%;
+    background-size: cover;
+    background-position: center center;
+    border: 2px solid $stickybar-border;
+    z-index: 2;
+
+    &:hover {
+      .removeButton {
+        display: block;
+      }
+    }
+
+    .removeButton {
+      display: none;
+      position: absolute;
+      top: 0;
+      right: 5px;
+      z-index: 3;
+    }
+  }
+}

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -54,7 +54,7 @@ const initialState = {
       img:
         'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.gentlemansgazette.com%2Fwp-content%2Fuploads%2F2015%2F10%2FA-completely-adjustable-ergonomic-chair.jpg&f=1&nofb=1&ipt=9a70c7dad3c09ca8f64932783c64c9b00eb590231807a58f6949796147db896c&ipo=images',
       favorite: false,
-      comparision: true,
+      comparision: false,
       description:
         'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sunt alias modi veniam facere veritatis debitis iste dolorum accusantium molestias animi.',
     },
@@ -70,7 +70,7 @@ const initialState = {
       img:
         'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fengineeringdiscoveries.com%2Fwp-content%2Fuploads%2F2021%2F04%2F6a7b51d92b1f3efedb994ee2620ddc56.jpg&f=1&nofb=1&ipt=ef7470c63a2514124c896467566df15b07403ef62bce7ef779659ccac7316a73&ipo=images',
       favorite: true,
-      comparision: true,
+      comparision: false,
       description:
         'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sunt alias modi veniam facere veritatis debitis iste dolorum accusantium molestias animi.',
     },

--- a/src/redux/productsRedux.js
+++ b/src/redux/productsRedux.js
@@ -5,12 +5,27 @@ export const getCount = ({ products }) => products.length;
 export const getNew = ({ products }) =>
   products.filter(item => item.newFurniture === true);
 
+export const getCompareProducts = ({ products }) =>
+  products.filter(product => product.comparision === true);
+
 /* actions */
 const createActionName = actionName => `app/product/${actionName}`;
 const ADD_USER_STARS = createActionName('ADD_USER_STARS');
+const ADD_PRODUCT_COMPARE = createActionName('ADD_PRODUCT_COMPARE');
+const REMOVE_PRODUCT_COMPARE = createActionName('REMOVE_PRODUCT_COMPARE');
 
 /* action creators */
 export const addUserStars = payload => ({ type: ADD_USER_STARS, payload });
+
+export const addToCompare = payload => ({
+  type: ADD_PRODUCT_COMPARE,
+  payload,
+});
+
+export const removeCompare = payload => ({
+  type: REMOVE_PRODUCT_COMPARE,
+  payload,
+});
 
 /* reducer */
 export default function reducer(statePart = [], action = {}) {
@@ -20,6 +35,14 @@ export default function reducer(statePart = [], action = {}) {
         product.id === action.payload.id
           ? { ...product, userStars: action.payload.userStars }
           : product
+      );
+    case ADD_PRODUCT_COMPARE:
+      return statePart.map(product =>
+        product.id === action.payload ? { ...product, comparision: true } : product
+      );
+    case REMOVE_PRODUCT_COMPARE:
+      return statePart.map(product =>
+        product.id === action.payload ? { ...product, comparision: false } : product
       );
     default:
       return statePart;

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -168,3 +168,7 @@ $productboxhorizontal-name-text: $orange;
 $brandbar-border: $cerebralGrey;
 $brandbar-arrow: $white;
 $brandbar-arrow-background: $black;
+
+/* StickyBar */
+$stickybar-border: $grey;
+$stickybar-background: $white;


### PR DESCRIPTION

![image](https://github.com/odevpl/wdp2403/assets/151070071/d577a283-9a53-43f8-8c6c-8505316a205b)

Każda karta produktu ma guzik do wybrania produktu do porównania. Kliknięcie w ten guzik ma zapisywać w stanie aplikacji produkty wybrane do porównania. Wybrane mogą być maksymalnie cztery produkty! Przy próbie dodania kolejnego należy zignorować kliknięcie (docelowo będzie jakiś komunikat).

Klient nie ma designu do tego, ale poprosił żebyśmy dodali sticky bar na dole viewportu, na którym będą obok siebie zdjęcia wybranych produktów. Na hover na zdjęciu ma się pojawiać ikona zamykania, a kliknięcie zdjęcie usuwa ten produkt z porównania). Obok produktów ma być guzik "Compare" (na razie ma niczego nie robić).

Wybrane produkty mają mieć ten guzik zawsze taki jak na hover (kremowy)

Przy odświeżeniu strony żaden produkt nie ma być wybrany.